### PR TITLE
suppress password echo from terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn main() -> Result<()> {
             _ = "password:" => {
                 if let Some(password) = password {
                     ssh.send_line(password)?;
+                    ssh.expect("\n")?;
                 } else {
                     print!("password:")
                 }


### PR DESCRIPTION
After sending the password via send_line, the PTY echoes the password text back to the terminal, making it visible in the output. This is a security issue as the password becomes readable in terminal scrollback and logs.

Consume the echoed line by calling expect("\n") right after send_line, which reads and discards the echoed password before entering interactive mode.