### PR TITLE
exit with error on missing command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,9 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    if args.command.is_empty() {
+        anyhow::bail!("No command specified. Usage: sshpass-rs [OPTIONS] -- <COMMAND>");
+    }
     let command = args.command.join(" ");
     let password = if let Some(password) = args.password {
         Some(password)


### PR DESCRIPTION
When no command is provided, the program panics with an unhelpful stack trace from the underlying process spawn. Replace the panic with a clear error message and a non-zero exit code using anyhow::bail.