### PR TITLE
match password prompt as 'assword:'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
             _ = "(yes/no/[fingerprint])" => {
                 ssh.send_line("yes")?;
             },
-            _ = "password:" => {
+            _ = "assword:" => {
                 if let Some(password) = password {
                     ssh.send_line(password)?;
                 } else {


### PR DESCRIPTION
Matching 'assword:' covers both 'password:' and 'Password:' as a simple literal substring match, which is the same approach used by the original sshpass.